### PR TITLE
Fixed 'EOF' error on OS X

### DIFF
--- a/nengo_ocl/clra_nonlinearities.py
+++ b/nengo_ocl/clra_nonlinearities.py
@@ -442,8 +442,8 @@ def plan_lif_rate(queue, J, R, ref, tau, dt, tag=None, n_elements=0):
     outputs = dict(r=R)
     parameters = dict(tau=tau, ref=ref)
     text = """
-            j = max(j - 1, 0.0f);
-            r = 1.0 / (ref + tau * log1p(1.0/j));
+            j = max(j - 1.0f, 0.0f);
+            r = 1.0f / (ref + tau * log1p(1.0f/j));
             """
 
     return _plan_template(

--- a/nengo_ocl/plan.py
+++ b/nengo_ocl/plan.py
@@ -1,7 +1,9 @@
 import time
-import pyopencl as cl
 from collections import defaultdict
+
 import networkx as nx
+import numpy as np
+import pyopencl as cl
 PROFILING_ENABLE = cl.command_queue_properties.PROFILING_ENABLE
 
 
@@ -100,9 +102,10 @@ class Marker(Plan):
 
     def __init__(self, queue):
         dummy = cl.Program(queue.context, """
-        __kernel void dummy() {}
+        __kernel void dummy(int foo) {}
         """).build().dummy
-        Plan.__init__(self, queue, dummy, (1,), None)
+        dummy.set_args(np.int32(0))
+        Plan.__init__(self, queue, dummy, gsize=(1,), lsize=None)
 
 
 class DAG(object):

--- a/nengo_ocl/sim_ocl.py
+++ b/nengo_ocl/sim_ocl.py
@@ -217,8 +217,10 @@ class Simulator(sim_npy.Simulator):
         V = self.all_data[[self.sidx[op.states[0]] for op in ops]]
         W = self.all_data[[self.sidx[op.states[1]] for op in ops]]
         S = self.all_data[[self.sidx[op.output] for op in ops]]
-        ref = self.RaggedArray([op.neurons.tau_ref for op in ops])
-        tau = self.RaggedArray([op.neurons.tau_rc for op in ops])
+        ref = self.RaggedArray(
+            [np.array(op.neurons.tau_ref, dtype=J.buf.dtype) for op in ops])
+        tau = self.RaggedArray(
+            [np.array(op.neurons.tau_rc, dtype=J.buf.dtype) for op in ops])
         dt = self.model.dt
         return [plan_lif(self.queue, J, V, W, V, W, S, ref, tau, dt,
                          tag="lif", n_elements=10)]
@@ -226,8 +228,10 @@ class Simulator(sim_npy.Simulator):
     def plan_SimLIFRate(self, ops):
         J = self.all_data[[self.sidx[op.J] for op in ops]]
         R = self.all_data[[self.sidx[op.output] for op in ops]]
-        ref = self.RaggedArray([op.neurons.tau_ref for op in ops])
-        tau = self.RaggedArray([op.neurons.tau_rc for op in ops])
+        ref = self.RaggedArray(
+            [np.array(op.neurons.tau_ref, dtype=J.buf.dtype) for op in ops])
+        tau = self.RaggedArray(
+            [np.array(op.neurons.tau_rc, dtype=J.buf.dtype) for op in ops])
         dt = self.model.dt
         return [plan_lif_rate(self.queue, J, R, ref, tau, dt,
                               tag="lif_rate", n_elements=10)]

--- a/nengo_ocl/sim_ocl.py
+++ b/nengo_ocl/sim_ocl.py
@@ -223,7 +223,7 @@ class Simulator(sim_npy.Simulator):
             [np.array(op.neurons.tau_rc, dtype=J.buf.dtype) for op in ops])
         dt = self.model.dt
         return [plan_lif(self.queue, J, V, W, V, W, S, ref, tau, dt,
-                         tag="lif", n_elements=10)]
+                         tag="lif", n_elements=2)]
 
     def plan_SimLIFRate(self, ops):
         J = self.all_data[[self.sidx[op.J] for op in ops]]
@@ -234,7 +234,7 @@ class Simulator(sim_npy.Simulator):
             [np.array(op.neurons.tau_rc, dtype=J.buf.dtype) for op in ops])
         dt = self.model.dt
         return [plan_lif_rate(self.queue, J, R, ref, tau, dt,
-                              tag="lif_rate", n_elements=10)]
+                              tag="lif_rate", n_elements=2)]
 
     def plan_SimSynapse(self, ops):
         for op in ops:


### PR DESCRIPTION
See issue #51 for a full description of the error. The fix is to
add a scalar argument to the dummy kernel used by `plan.py:Marker`.

Hopefully this works. @jgosmann, can you check and make sure this fixes the problem on OS X?