### PR TITLE
V1.0.0pre

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,14 +13,37 @@ Release History
 
 .. Changes should be organized in one of several sections:
 
-   - API changes
+   - Features
    - Improvements
-   - Behavioural changes
    - Bugfixes
    - Documentation
 
-0.1.1 (unreleased)
+1.0.0 (unreleased)
 ==================
+
+Release in support of Nengo 2.1.0.
+
+**Features**
+
+- Added support for ``Process`` class and subclasses, new in Nengo in 2.1.0.
+  We specifically support the ``WhiteNoise``, ``WhiteSignal``, and
+  ``PresentInput`` processes. We also support the ``Conv2d`` and ``Pool2d``
+  processes in ``nengo_extras``.
+- ``LinearFilter`` is now fully supported, allowing for general synapses.
+
+**Improvements**
+
+- The Numpy simulator in this project (``sim_npy``) has been phased out and
+  combined with the OCL simulator (``sim_ocl``). It is now called ``Simulator``
+  and resides in ``simulator.py``.
+- Operator scheduling (i.e. the planner) is much faster. We still have only
+  one planner (``greedy_planner``), which now resides in ``planners.py``.
+- Many small speed improvements, including a number of cases where data was
+  needlessly copied off the device to check sizes, dtypes, etc.
+
+**Documentation**
+
+- Updated examples to use up-to-date Nengo syntax.
 
 0.1.0 (June 8, 2015)
 ====================

--- a/nengo_ocl/tests/conftest.py
+++ b/nengo_ocl/tests/conftest.py
@@ -1,11 +1,17 @@
 import nengo
 from nengo.conftest import *  # noqa: F403
+import pyopencl as cl
+
+import nengo_ocl
 
 
-def pytest_generate_tests(metafunc):
-    if "nl" in metafunc.funcargnames:
-        metafunc.parametrize(
-            "nl", [nengo.Direct, nengo.LIF, nengo.LIFRate])
-    if "nl_nodirect" in metafunc.funcargnames:
-        metafunc.parametrize(
-            "nl_nodirect", [nengo.LIF, nengo.LIFRate])
+ctx = cl.create_some_context()
+
+
+class OclSimulator(nengo_ocl.Simulator):
+    def __init__(self, *args, **kwargs):
+        super(OclSimulator, self).__init__(*args, context=ctx, **kwargs)
+
+
+TestConfig.Simulator = OclSimulator
+TestConfig.neuron_types = [nengo.Direct, nengo.LIF, nengo.LIFRate]

--- a/nengo_ocl/tests/test_nengo.py
+++ b/nengo_ocl/tests/test_nengo.py
@@ -12,26 +12,10 @@ See http://pytest.org/latest/usage.html for more invocations.
 import sys
 import os
 
-import pyopencl as cl
-import pytest
-
 import nengo
 import nengo.tests.test_synapses
-from nengo.utils.testing import find_modules, allclose
-
-import nengo_ocl
-from nengo_ocl.tests.utils import load_functions
-
-ctx = cl.create_some_context()
-
-
-def OclSimulator(*args, **kwargs):
-    return nengo_ocl.Simulator(*args, context=ctx, **kwargs)
-
-
-def pytest_funcarg__Simulator(request):
-    """The Simulator class being tested."""
-    return OclSimulator
+from nengo.utils.testing import allclose, find_modules, load_functions
+import pytest
 
 
 def allclose_tol(*args, **kwargs):
@@ -48,14 +32,14 @@ nengo.tests.test_synapses.allclose = allclose_tol  # looser tolerances
 
 locals().update(tests)
 
-# --- nengo_deeplearning
+# --- nengo_extras
 try:
-    import nengo_deeplearning
+    import nengo_extras
 except ImportError:
     pass
 else:
-    nengo_deeplearning_dir = os.path.dirname(nengo_deeplearning.__file__)
-    modules = find_modules(nengo_deeplearning_dir, prefix='nengo_deeplearning')
+    nengo_extras_dir = os.path.dirname(nengo_extras.__file__)
+    modules = find_modules(nengo_extras_dir, prefix='nengo_extras')
     tests = load_functions(modules, arg_pattern='^Simulator$')
     locals().update(tests)
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,0 @@
-matplotlib>=1.4
-pytest>=2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy
-nengo
-mako
-pyopencl

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,6 @@ def read(*filenames, **kwargs):
 root = os.path.dirname(os.path.realpath(__file__))
 version_module = imp.load_source(
     'version', os.path.join(root, 'nengo_ocl', 'version.py'))
-description = ("OpenCL-backed neural simulations using the methods "
-               "of the Neural Engineering Framework.")
-long_description = read('README.rst', 'CHANGES.rst')
 
 setup(
     name="nengo_ocl",
@@ -35,13 +32,30 @@ setup(
     author_email="info@appliedbrainresearch.com",
     packages=find_packages(),
     scripts=[],
+    data_files=[],
     url="https://github.com/nengo/nengo_ocl",
-    license="See LICENSE.rst",
-    description=description,
-    long_description=long_description,
+    license="Free for non-commercial use",
+    description=("OpenCL-backed neural simulations using the "
+                 "Neural Engineering Framework"),
+    long_description=read('README.rst', 'CHANGES.rst'),
+    zip_safe=False,
     install_requires=[
-        "nengo",
-        "networkx",
-        "pyopencl",
+        'nengo',
+        'mako',
+        'pyopencl',
     ],
+    tests_require=[
+        'matplotlib>=1.4',
+        'pytest>=2.9',
+    ],
+    classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Science/Research',
+        'License :: Free for non-commercial use',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    ]
 )


### PR DESCRIPTION
Things to prepare for the 1.0.0 release.

@tbekolay, I might be asking for your help with some of this stuff.

The first thing I'm trying to do is get the `setup.py` file in order. I'm requiring `nengo>=2.1.0`, but when I `python setup.py develop` it installs nengo 2.1.0 even though I have the current nengo development version on my install path. Is this expected?

TODO (see `nengo/docs/releasing.rst`):
- [ ] Update changelog. A lot changed. Brief summaries should do.