### PR TITLE
More improvements to Conv2d speed

### DIFF
--- a/nengo_ocl/clra_nonlinearities.py
+++ b/nengo_ocl/clra_nonlinearities.py
@@ -1457,18 +1457,17 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
         __global ${type} *y
     )
     {
-        const int j = get_global_id(0);
-        const int i = get_global_id(1);
-        const int k = get_global_id(2);
+        const int j = get_global_id(1);
+        const int i = get_global_id(2);
+        const int k = get_global_id(0);
         const int ij = i*${nyj} + j;
-        const int ijk = k*${nyi*nyj} + i*${nyj} + j;
 
-        const int tj = get_local_id(0);
-        const int ti = get_local_id(1);
-        const int tk = get_local_id(2);
-        const int lsizej = get_local_size(0);
-        const int lsizei = get_local_size(1);
-        const int lsizek = get_local_size(2);
+        const int tj = get_local_id(1);
+        const int ti = get_local_id(2);
+        const int tk = get_local_id(0);
+        const int lsizej = get_local_size(1);
+        const int lsizei = get_local_size(2);
+        const int lsizek = get_local_size(0);
 
         const int lsizeij = lsizei*lsizej;
         const int tij = tj + ti*lsizej;
@@ -1480,15 +1479,16 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
         const int i0 = (i - ti)*${sti} - ${pi};
         __local ${type} patch[${nipatch}][${njpatch}];
     % if conv:
-        __local ${type} filter[${nf_per}][${si*sj}];
-        f += k*${nc*si*sj};
+        __local ${type} filter[${si*sj}][${nf_per}];
+        f += k;
     % else:
-        f += k*${nc*si*sj*nyi*nyj} + ij;
+        f += ij*${nf} + k;
     % endif
         x += ${xstart};
         y += ${ystart};
 
-        ${type} out = b[ijk];
+        const int out_ijk = k*${nyi*nyj} + i*${nyj} + j;
+        ${type} out = b[out_ijk];
 
         for (int c = 0; c < ${nc}; c++) {
 
@@ -1507,11 +1507,11 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
 
     % if conv:
             // load filters
-            __global const ${type} *fc = f + c*${si*sj};
+            __global const ${type} *fc = f + c*${si*sj*nf};
             for (int kij = tij; kij < ${si*sj}; kij += lsizeij)
-                filter[tk][kij] = fc[kij];
+                filter[kij][tk] = fc[kij*${nf}];
     % else:
-            __global const ${type} *filter = f + c*${si*sj*nyi*nyj};
+            __global const ${type} *filter = f + c*${si*sj*nyi*nyj*nf};
     % endif
             barrier(CLK_LOCAL_MEM_FENCE);
 
@@ -1519,16 +1519,16 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
             for (int jj = 0; jj < ${sj}; jj++)
                 out += patch[${sti}*ti+ii][${stj}*tj+jj]
     % if conv:
-                    * filter[tk][ii*${sj}+jj];
+                    * filter[ii*${sj}+jj][tk];
     % else:
-                    * filter[(ii*${sj}+jj)*${nyi*nyj}];
+                    * filter[(ii*${sj}+jj)*${nyi*nyj*nf}];
     % endif
 
             barrier(CLK_LOCAL_MEM_FENCE);
         }
 
         if (i < ${nyi} && j < ${nyj} && k < ${nf})
-            y[ijk] = out;
+            y[out_ijk] = out;
     }
     """
 
@@ -1542,10 +1542,19 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
     # max_group = get_mwgs(queue, cap=256)
     assert max_group >= 32
 
-    lsize = (6, 6, 4)
-    gsize = (round_up(nyj, lsize[0]),
-             round_up(nyi, lsize[1]),
-             round_up(nf, lsize[2]))
+    # # lsize = (8, 8, 4)
+    # lsize = (4, 4, 16)
+    # gsize = (round_up(nyj, lsize[0]),
+    #          round_up(nyi, lsize[1]),
+    #          round_up(nf, lsize[2]))
+
+    lsize = (16, 4, 4)
+    # lsize = (32, 4, 4)
+    # lsize = (32, 4, 1)
+    gsize = (round_up(nf, lsize[0]),
+             round_up(nyj, lsize[1]),
+             round_up(nyi, lsize[2]),
+    )
 
     # lsize0 = min(nyj, 32)
     # lsize1 = min(max_group // lsize0, nyi, 32)

--- a/nengo_ocl/clra_nonlinearities.py
+++ b/nengo_ocl/clra_nonlinearities.py
@@ -433,7 +433,13 @@ def plan_elementwise_inc(queue, A, X, Y, tag=None):
             __global ${Ytype} *Ydata
         )
         {
+            const int ij = get_global_id(0);
             const int n = get_global_id(1);
+
+            const int Yshape1 = Yshape1s[n];
+            if (ij >= Yshape0s[n] * Yshape1)
+                return;
+
             __global const ${Atype} *a = Adata + Astarts[n];
             __global const ${Xtype} *x = Xdata + Xstarts[n];
             __global ${Ytype} *y = Ydata + Ystarts[n];
@@ -444,21 +450,14 @@ def plan_elementwise_inc(queue, A, X, Y, tag=None):
             const int Xshape0 = Xshape0s[n];
             const int Xshape1 = Xshape1s[n];
             const int Xstride0 = Xstride0s[n];
-            const int Yshape1 = Yshape1s[n];
             const int Ystride0 = Ystride0s[n];
-            const int Ysize = Yshape0s[n] * Yshape1;
 
-            for (int ij = get_global_id(0);
-                 ij < Ysize;
-                 ij += get_global_size(0))
-            {
-                int i = ij / Yshape1;
-                int j = ij % Yshape1;
+            int i = ij / Yshape1;
+            int j = ij % Yshape1;
 
-                ${Atype} aa = get_element(a, Ashape0, Ashape1, Astride0, i, j);
-                ${Xtype} xx = get_element(x, Xshape0, Xshape1, Xstride0, i, j);
-                y[i * Ystride0 + j] += aa * xx;
-            }
+            ${Atype} aa = get_element(a, Ashape0, Ashape1, Astride0, i, j);
+            ${Xtype} xx = get_element(x, Xshape0, Xshape1, Xstride0, i, j);
+            y[i * Ystride0 + j] += aa * xx;
         }
         """
 
@@ -485,13 +484,13 @@ def plan_elementwise_inc(queue, A, X, Y, tag=None):
     _fn = cl.Program(queue.context, text).build().elementwise_inc
     _fn.set_args(*[arr.data for arr in full_args])
 
-    mn = min(Y.sizes.max(), get_mwgs(queue))
+    mn = Y.sizes.max()
     gsize = (mn, N)
-    # lsize = (mn, 1)
     lsize = None
     rval = Plan(
         queue, _fn, gsize, lsize=lsize, name="cl_elementwise_inc", tag=tag)
     rval.full_args = full_args     # prevent garbage-collection
+    rval.flops_per_call = 2 * Y.sizes.sum()
     rval.bw_per_call = A.nbytes + X.nbytes + Y.nbytes
     rval.description = (
         "groups: %d; items: %d; items/group: %0.1f [%d, %d]" %

--- a/nengo_ocl/clra_nonlinearities.py
+++ b/nengo_ocl/clra_nonlinearities.py
@@ -1461,31 +1461,40 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
         const int i = get_global_id(1);
         const int k = get_global_id(2);
         const int ij = i*${nyj} + j;
+        const int ijk = k*${nyi*nyj} + i*${nyj} + j;
 
         const int tj = get_local_id(0);
         const int ti = get_local_id(1);
+        const int tk = get_local_id(2);
         const int lsizej = get_local_size(0);
         const int lsizei = get_local_size(1);
-        const int lsize = lsizei * lsizej;
-        const int tij = ti*lsizej + tj;
+        const int lsizek = get_local_size(2);
+
+        const int lsizeij = lsizei*lsizej;
+        const int tij = tj + ti*lsizej;
+
+        const int lsize = lsizei*lsizej*lsizek;
+        const int tijk = get_local_id(0) + get_local_id(1)*get_local_size(0) +
+                         get_local_id(2)*get_local_size(0)*get_local_size(1);
         const int j0 = (j - tj)*${stj} - ${pj};
         const int i0 = (i - ti)*${sti} - ${pi};
         __local ${type} patch[${nipatch}][${njpatch}];
     % if conv:
-        __local ${type} filter[${si*sj}];
+        __local ${type} filter[${nf_per}][${si*sj}];
+        f += k*${nc*si*sj};
     % else:
-        f += ij;
+        f += k*${nc*si*sj*nyi*nyj} + ij;
     % endif
         x += ${xstart};
         y += ${ystart};
 
-        ${type} out = b[k*${nyi*nyj} + ij];
+        ${type} out = b[ijk];
 
         for (int c = 0; c < ${nc}; c++) {
 
             // load image section
             __global const ${type} *xc = &x[c * ${nxi * nxj}];
-            for (int kij = tij; kij < ${npatch}; kij += lsize) {
+            for (int kij = tijk; kij < ${npatch}; kij += lsize) {
                 const int ki = kij / ${njpatch};
                 const int kj = kij % ${njpatch};
                 const int ii = i0 + ki;
@@ -1498,27 +1507,28 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
 
     % if conv:
             // load filters
-            __global const ${type} *fc = f + k*${nc*si*sj} + c*${si*sj};
-            for (int kij = tij; kij < ${si*sj}; kij += lsize) {
-                filter[kij] = fc[kij];
-            }
+            __global const ${type} *fc = f + c*${si*sj};
+            for (int kij = tij; kij < ${si*sj}; kij += lsizeij)
+                filter[tk][kij] = fc[kij];
+    % else:
+            __global const ${type} *filter = f + c*${si*sj*nyi*nyj};
     % endif
             barrier(CLK_LOCAL_MEM_FENCE);
 
             for (int ii = 0; ii < ${si}; ii++)
             for (int jj = 0; jj < ${sj}; jj++)
+                out += patch[${sti}*ti+ii][${stj}*tj+jj]
     % if conv:
-                out += filter[ii*${sj}+jj] * patch[${sti}*ti+ii][${stj}*tj+jj];
+                    * filter[tk][ii*${sj}+jj];
     % else:
-                out += f[((k*${nc} + c)*${si*sj} + ii*${sj} + jj)*${nyi*nyj}]
-                       * patch[${sti}*ti+ii][${stj}*tj+jj];
+                    * filter[(ii*${sj}+jj)*${nyi*nyj}];
     % endif
 
             barrier(CLK_LOCAL_MEM_FENCE);
         }
 
-        if (i < ${nyi} && j < ${nyj})
-            y[k*${nyi*nyj} + ij] = out;
+        if (i < ${nyi} && j < ${nyj} && k < ${nf})
+            y[ijk] = out;
     }
     """
 
@@ -1529,11 +1539,30 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
     sti, stj = strides
 
     max_group = get_mwgs(queue, cap=128)
+    # max_group = get_mwgs(queue, cap=256)
     assert max_group >= 32
-    lsize0 = min(nyj, 32)
-    lsize1 = min(max_group // lsize0, nyi)
-    lsize = (lsize0, lsize1, 1)
-    gsize = (round_up(nyj, lsize[0]), round_up(nyi, lsize[1]), nf)
+
+    lsize = (6, 6, 4)
+    gsize = (round_up(nyj, lsize[0]),
+             round_up(nyi, lsize[1]),
+             round_up(nf, lsize[2]))
+
+    # lsize0 = min(nyj, 32)
+    # lsize1 = min(max_group // lsize0, nyi, 32)
+    # lsize2 = min(max_group // (lsize0 * lsize1), nf)
+    # lsize = (lsize0, lsize1, lsize2)
+    # gsize = (round_up(nyj, lsize[0]),
+    #          round_up(nyi, lsize[1]),
+    #          round_up(nf, lsize[2]))
+    # print(lsize)
+    # print(gsize)
+
+    # lsize0 = min(nyj, 32)
+    # lsize1 = min(max_group // lsize0, nyi)
+    # lsize = (lsize0, lsize1, 1)
+    # gsize = (round_up(nyj, lsize[0]),
+    #          round_up(nyi, lsize[1]),
+    #          nf)
 
     njpatch = (lsize[0] - 1) * stj + sj
     nipatch = (lsize[1] - 1) * sti + si
@@ -1546,7 +1575,7 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
     textconf = dict(
         type=X.ctype, conv=conv, nf=nf, nxi=nxi, nxj=nxj, nyi=nyi, nyj=nyj,
         nc=nc, si=si, sj=sj, pi=pi, pj=pj, sti=sti, stj=stj,
-        nipatch=nipatch, njpatch=njpatch, npatch=npatch,
+        nipatch=nipatch, njpatch=njpatch, npatch=npatch, nf_per=lsize[2],
         xstart=X.start, ystart=Y.start)
     text = as_ascii(Template(text, output_encoding='ascii').render(**textconf))
 

--- a/nengo_ocl/clra_nonlinearities.py
+++ b/nengo_ocl/clra_nonlinearities.py
@@ -115,9 +115,9 @@ def plan_timeupdate(queue, step, time, dt):
 
     gsize = (1,)
     lsize = None
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_timeupdate")
-    rval.full_args = full_args     # prevent garbage-collection
-    return rval
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_timeupdate")
+    plan.full_args = full_args     # prevent garbage-collection
+    return plan
 
 
 def plan_reset(queue, Y, values, tag=None):
@@ -177,14 +177,14 @@ def plan_reset(queue, Y, values, tag=None):
     _fn = cl.Program(queue.context, text).build().reset
     _fn.set_args(*[arr.data for arr in full_args])
 
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_reset", tag=tag)
-    rval.full_args = full_args     # prevent garbage-collection
-    rval.bw_per_call = (
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_reset", tag=tag)
+    plan.full_args = full_args     # prevent garbage-collection
+    plan.bw_per_call = (
         Y.nbytes + values.nbytes + clYsizes.nbytes + clYstarts.nbytes)
-    rval.description = (
+    plan.description = (
         "groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
         (len(Y), Y.sizes.sum(), Y.sizes.mean(), Y.sizes.min(), Y.sizes.max()))
-    return rval
+    return plan
 
 
 def plan_copy(queue, A, B, incs, tag=None):
@@ -265,13 +265,13 @@ def plan_copy(queue, A, B, incs, tag=None):
     _fn = cl.Program(queue.context, text).build().copy
     _fn.set_args(*[arr.data for arr in full_args])
 
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_copy", tag=tag)
-    rval.full_args = tuple(full_args)  # prevent garbage-collection
-    rval.bw_per_call = A.nbytes + B.nbytes
-    rval.description = (
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_copy", tag=tag)
+    plan.full_args = tuple(full_args)  # prevent garbage-collection
+    plan.bw_per_call = A.nbytes + B.nbytes
+    plan.description = (
         "groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
         (len(A), A.sizes.sum(), A.sizes.mean(), A.sizes.min(), A.sizes.max()))
-    return rval
+    return plan
 
 
 def plan_slicedcopy(queue, A, B, Ainds, Binds, incs, tag=None):
@@ -369,14 +369,14 @@ def plan_slicedcopy(queue, A, B, Ainds, Binds, incs, tag=None):
     _fn = cl.Program(queue.context, text).build().slicedcopy
     _fn.set_args(*[arr.data for arr in full_args])
 
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_slicedcopy", tag=tag)
-    rval.full_args = tuple(full_args)  # prevent garbage-collection
-    rval.bw_per_call = 2 * (Ainds.nbytes + Ainds.sizes.sum()*A.dtype.itemsize)
-    rval.description = (
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_slicedcopy", tag=tag)
+    plan.full_args = tuple(full_args)  # prevent garbage-collection
+    plan.bw_per_call = 2 * (Ainds.nbytes + Ainds.sizes.sum()*A.dtype.itemsize)
+    plan.description = (
         "groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
         (len(Ainds), Ainds.sizes.sum(),
          Ainds.sizes.mean(), Ainds.sizes.min(), Ainds.sizes.max()))
-    return rval
+    return plan
 
 
 def plan_elementwise_inc(queue, A, X, Y, tag=None):
@@ -487,15 +487,15 @@ def plan_elementwise_inc(queue, A, X, Y, tag=None):
     mn = Y.sizes.max()
     gsize = (mn, N)
     lsize = None
-    rval = Plan(
+    plan = Plan(
         queue, _fn, gsize, lsize=lsize, name="cl_elementwise_inc", tag=tag)
-    rval.full_args = full_args     # prevent garbage-collection
-    rval.flops_per_call = 2 * Y.sizes.sum()
-    rval.bw_per_call = A.nbytes + X.nbytes + Y.nbytes
-    rval.description = (
+    plan.full_args = full_args     # prevent garbage-collection
+    plan.flops_per_call = 2 * Y.sizes.sum()
+    plan.bw_per_call = A.nbytes + X.nbytes + Y.nbytes
+    plan.description = (
         "groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
         (len(Y), Y.sizes.sum(), Y.sizes.mean(), Y.sizes.min(), Y.sizes.max()))
-    return rval
+    return plan
 
 
 def plan_linearfilter(queue, X, Y, A, B, Xbuf, Ybuf, tag=None):
@@ -785,16 +785,16 @@ def plan_probes(queue, periods, X, Y, tag=None):
     max_len = min(max(X.shape0s), get_mwgs(queue))
     gsize = (max_len, N,)
     lsize = (max_len, 1)
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_probes", tag=tag)
-    rval.full_args = full_args     # prevent garbage-collection
-    rval.cl_bufpositions = cl_bufpositions
-    rval.Y = Y
-    rval.bw_per_call = (2*X.nbytes + cl_periods.nbytes +
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_probes", tag=tag)
+    plan.full_args = full_args     # prevent garbage-collection
+    plan.cl_bufpositions = cl_bufpositions
+    plan.Y = Y
+    plan.bw_per_call = (2*X.nbytes + cl_periods.nbytes +
                         cl_countdowns.nbytes + cl_bufpositions.nbytes)
-    rval.description = (
+    plan.description = (
         "groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
         (len(X), X.sizes.sum(), X.sizes.mean(), X.sizes.min(), X.sizes.max()))
-    return rval
+    return plan
 
 
 def plan_direct(queue, code, init, input_names, inputs, output, tag=None):
@@ -857,13 +857,13 @@ ${code}
     _fn.set_args(*[arr.data for arr in full_args])
 
     gsize = (N,)
-    rval = Plan(queue, _fn, gsize, lsize=None, name="cl_direct", tag=tag)
-    rval.full_args = tuple(full_args)  # prevent garbage-collection
-    rval.description = (
+    plan = Plan(queue, _fn, gsize, lsize=None, name="cl_direct", tag=tag)
+    plan.full_args = tuple(full_args)  # prevent garbage-collection
+    plan.description = (
         "groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
         (len(output), output.sizes.sum(),
          output.sizes.mean(), output.sizes.min(), output.sizes.max()))
-    return rval
+    return plan
 
 
 def plan_lif(queue, dt, J, V, W, outS, ref, tau, N=None, tau_n=None,
@@ -1143,13 +1143,13 @@ def _plan_template(queue, name, core_text, declares="", tag=None,
     _fn = getattr(fns, fn_name)
     _fn.set_args(*[arr.data for arr in full_args])
 
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name=name, tag=tag)
-    rval.full_args = tuple(full_args)  # prevent garbage-collection
-    rval.bw_per_call = bw_per_call
-    rval.description = ("groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name=name, tag=tag)
+    plan.full_args = tuple(full_args)  # prevent garbage-collection
+    plan.bw_per_call = bw_per_call
+    plan.description = ("groups: %d; items: %d; items/group: %0.1f [%d, %d]" %
                         (gsize[1], input0.sizes.sum(), input0.sizes.mean(),
                          input0.sizes.min(), input0.sizes.max()))
-    return rval
+    return plan
 
 
 def create_rngs(queue, n):
@@ -1340,9 +1340,9 @@ def plan_whitenoise(queue, Y, dist_enums, dist_params, scale, inc, dt, rngs,
     max_len = min(min(rngs.shape0s), max(Y.shape0s))
     gsize = (max_len, N)
     lsize = (max_len, 1)
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_whitenoise", tag=tag)
-    rval.full_args = full_args     # prevent garbage-collection
-    return rval
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_whitenoise", tag=tag)
+    plan.full_args = full_args     # prevent garbage-collection
+    return plan
 
 
 def plan_presentinput(queue, Y, t, signals, dt, pres_t=None, tag=None):
@@ -1421,10 +1421,10 @@ def plan_presentinput(queue, Y, t, signals, dt, pres_t=None, tag=None):
     max_len = min(max(Y.shape0s), get_mwgs(queue))
     gsize = (max_len, N)
     lsize = (max_len, 1)
-    rval = Plan(
+    plan = Plan(
         queue, _fn, gsize, lsize=lsize, name="cl_presentinput", tag=tag)
-    rval.full_args = full_args     # prevent garbage-collection
-    return rval
+    plan.full_args = full_args     # prevent garbage-collection
+    return plan
 
 
 def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
@@ -1554,11 +1554,11 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
     _fn = cl.Program(queue.context, text).build().conv2d
     _fn.set_args(*full_args)
 
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_conv2d", tag=tag)
-    rval.full_args = full_args     # prevent garbage-collection
-    rval.flops_per_call = 2 * nyi * nyj * nf * nc * si * sj
-    rval.bw_per_call = X.nbytes + filters.nbytes + biases.nbytes + Y.nbytes
-    return rval
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_conv2d", tag=tag)
+    plan.full_args = full_args     # prevent garbage-collection
+    plan.flops_per_call = 2 * nyi * nyj * nf * nc * si * sj
+    plan.bw_per_call = X.nbytes + filters.nbytes + biases.nbytes + Y.nbytes
+    return plan
 
 
 def plan_pool2d(queue, X, Y, shape, size, stride, tag=None):
@@ -1651,8 +1651,8 @@ def plan_pool2d(queue, X, Y, shape, size, stride, tag=None):
     _fn = cl.Program(queue.context, text).build().pool2d
     _fn.set_args(*full_args)
 
-    rval = Plan(queue, _fn, gsize, lsize=lsize, name="cl_pool2d", tag=tag)
-    rval.full_args = full_args     # prevent garbage-collection
-    rval.flops_per_call = X.size
-    rval.bw_per_call = X.nbytes + Y.nbytes
-    return rval
+    plan = Plan(queue, _fn, gsize, lsize=lsize, name="cl_pool2d", tag=tag)
+    plan.full_args = full_args     # prevent garbage-collection
+    plan.flops_per_call = X.size
+    plan.bw_per_call = X.nbytes + Y.nbytes
+    return plan

--- a/nengo_ocl/clra_nonlinearities.py
+++ b/nengo_ocl/clra_nonlinearities.py
@@ -1459,6 +1459,7 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
     {
         const int j = get_global_id(0);
         const int i = get_global_id(1);
+        const int k = get_global_id(2);
         const int ij = i*${nyj} + j;
 
         const int tj = get_local_id(0);
@@ -1478,16 +1479,15 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
         x += ${xstart};
         y += ${ystart};
 
-        const int kk = get_global_id(2);
-        ${type} out = b[kk*${nyi*nyj} + ij];
+        ${type} out = b[k*${nyi*nyj} + ij];
 
         for (int c = 0; c < ${nc}; c++) {
 
             // load image section
             __global const ${type} *xc = &x[c * ${nxi * nxj}];
-            for (int k = tij; k < ${npatch}; k += lsize) {
-                const int ki = k / ${njpatch};
-                const int kj = k % ${njpatch};
+            for (int kij = tij; kij < ${npatch}; kij += lsize) {
+                const int ki = kij / ${njpatch};
+                const int kj = kij % ${njpatch};
                 const int ii = i0 + ki;
                 const int jj = j0 + kj;
                 if (ii >= 0 && ii < ${nxi} && jj >= 0 && jj < ${nxj})
@@ -1498,9 +1498,9 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
 
     % if conv:
             // load filters
-            __global const ${type} *fc = f + kk*${nc*si*sj} + c*${si*sj};
-            for (int k = tij; k < ${si*sj}; k += lsize) {
-                filter[k] = fc[k];
+            __global const ${type} *fc = f + k*${nc*si*sj} + c*${si*sj};
+            for (int kij = tij; kij < ${si*sj}; kij += lsize) {
+                filter[kij] = fc[kij];
             }
     % endif
             barrier(CLK_LOCAL_MEM_FENCE);
@@ -1510,7 +1510,7 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
     % if conv:
                 out += filter[ii*${sj}+jj] * patch[${sti}*ti+ii][${stj}*tj+jj];
     % else:
-                out += f[((kk*${nc} + c)*${si*sj} + ii*${sj} + jj)*${nyi*nyj}]
+                out += f[((k*${nc} + c)*${si*sj} + ii*${sj} + jj)*${nyi*nyj}]
                        * patch[${sti}*ti+ii][${stj}*tj+jj];
     % endif
 
@@ -1518,7 +1518,7 @@ def plan_conv2d(queue, X, Y, filters, biases, shape_in, shape_out,
         }
 
         if (i < ${nyi} && j < ${nyj})
-            y[kk*${nyi*nyj} + ij] = out;
+            y[k*${nyi*nyj} + ij] = out;
     }
     """
 
@@ -1597,9 +1597,9 @@ def plan_pool2d(queue, X, Y, shape, size, stride, tag=None):
 
         // load image patch
         __global const ${type} *xc = &x[c * ${nxi * nxj}];
-        for (int k = tij; k < ${nipatch * njpatch}; k += lsize) {
-            const int ki = k / ${njpatch};
-            const int kj = k % ${njpatch};
+        for (int kij = tij; kij < ${nipatch * njpatch}; kij += lsize) {
+            const int ki = kij / ${njpatch};
+            const int kj = kij % ${njpatch};
             const int ii = i0*${st} + ki;
             const int jj = j0*${st} + kj;
             if (ii >= 0 && ii < ${nxi} && jj >= 0 && jj < ${nxj})

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -756,8 +756,8 @@ class Simulator(nengo.Simulator):
             conv = (f.ndim == 4)
             X = self.all_data.getitem_device(self.sidx[op.input])
             Y = self.all_data.getitem_device(self.sidx[op.output])
-            f = np.array(np.transpose(
-                f, (1, 2, 3, 0) if conv else (3, 4, 5, 0, 1, 2)), order='C')
+            f = np.asarray(np.transpose(
+                f, (0, 1, 2, 3) if conv else (0, 3, 4, 5, 1, 2)), order='C')
             F = self.Array(f.ravel())
             B = self.Array((np.zeros(p.shape_out) + b).ravel())
             plans.append(plan_conv2d(

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -702,7 +702,7 @@ class Simulator(nengo.Simulator):
         Ybuf = CLRaggedArray(self.queue, Ybuf0)
         self._raggedarrays_to_reset[Xbuf] = Xbuf0
         self._raggedarrays_to_reset[Ybuf] = Ybuf0
-        return [plan_linearfilter(self.queue, X, Y, A, B, Xbuf, Ybuf)]
+        return plan_linearfilter(self.queue, X, Y, A, B, Xbuf, Ybuf)
 
     def _plan_WhiteNoise(self, ops):
         assert all(op.input is None for op in ops)

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -754,17 +754,18 @@ class Simulator(nengo.Simulator):
             p, f, b = op.process, op.process.filters, op.process.biases
             assert f.ndim in [4, 6]
             conv = (f.ndim == 4)
+            kernel_shape = f.shape[-2:]
             X = self.all_data.getitem_device(self.sidx[op.input])
             Y = self.all_data.getitem_device(self.sidx[op.output])
-            f = np.asarray(np.transpose(
+            ftrans = np.asarray(np.transpose(
                 f, (0, 1, 2, 3) if conv else (0, 3, 4, 5, 1, 2)), order='C')
-            F = self.Array(f.ravel())
+            F = self.Array(ftrans.ravel())
             B = self.Array((np.zeros(p.shape_out) + b).ravel())
             plans.append(plan_conv2d(
                 self.queue, X, Y, F, B, p.shape_in, p.shape_out,
-                p.filters.shape[-2:], conv, p.padding, p.stride,
+                kernel_shape, conv, p.padding, p.stride,
                 tag="shape_in=%s, shape_out=%s, kernel=%s, conv=%s" % (
-                    p.shape_in, p.shape_out, f.shape[-2:], conv)))
+                    p.shape_in, p.shape_out, kernel_shape, conv)))
 
         return plans
 

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -758,7 +758,7 @@ class Simulator(nengo.Simulator):
             X = self.all_data.getitem_device(self.sidx[op.input])
             Y = self.all_data.getitem_device(self.sidx[op.output])
             ftrans = np.asarray(np.transpose(
-                f, (0, 1, 2, 3) if conv else (0, 3, 4, 5, 1, 2)), order='C')
+                f, (1, 2, 3, 0) if conv else (3, 4, 5, 1, 2, 0)), order='C')
             F = self.Array(ftrans.ravel())
             B = self.Array((np.zeros(p.shape_out) + b).ravel())
             plans.append(plan_conv2d(


### PR DESCRIPTION
Trying computing multiple filters per group to reduce the number of times the image has to be loaded. So far, it hasn't seemed to help that much, though.

Maybe it makes sense that this doesn't help. For global filters (convolution), the limiting factor seems to be FLOPS, not memory access, so reducing image loads wouldn't make a difference.

For local filters, the amount of memory in the filters (nf * ni * nj * nc * si * sj) is much greater than in the image (ni * nj * nc), assuming the filter stride is 1, so reducing image loads won't make a difference. It would only be the case when the stride is about the size of the kernel width that the image data would be on par with the filter data for one workgroup, and so in this case computing multiple kernels per group might help.