### PR TITLE
Fix benchmark and cache on Python 3

### DIFF
--- a/examples/benchmark_circconv.py
+++ b/examples/benchmark_circconv.py
@@ -1,6 +1,9 @@
 from collections import OrderedDict
 import datetime
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 import sys
 import time
 

--- a/examples/view_records.py
+++ b/examples/view_records.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 import sys
-import cPickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from collections import OrderedDict
 
 by_name = OrderedDict()
 
 for recfile in sys.argv[1:]:
-    records = cPickle.load(open(recfile))
+    records = pickle.load(open(recfile, 'rb'))
     for rec in records:
         rec['filename'] = recfile
         by_name.setdefault(rec['name'], []).append(rec)

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -289,11 +289,16 @@ class Simulator(nengo.Simulator):
         # --- Nengo build
         self.closed = False
 
-        with Timer() as nengo_timer:
+        if model is None or model.decoder_cache is None:
+            cache = get_default_decoder_cache()
+        else:
+            cache = model.decoder_cache
+
+        with cache, Timer() as nengo_timer:
             if model is None:
                 self.model = Model(dt=float(dt),
                                    label="%s, dt=%f" % (network, dt),
-                                   decoder_cache=get_default_decoder_cache())
+                                   decoder_cache=cache)
             else:
                 self.model = model
 


### PR DESCRIPTION
When running benchmark_circconv.py with ocl, the following exceptions are observed:

Traceback (most recent call last):
  File "/home/shaun/dev/nengo/nengo/nengo/cache.py", line 375, in cached_solver
    path, start, end = self._index[key]
TypeError: 'NoneType' object is not subscriptable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "benchmark_circconv.py", line 75, in <module>
    sim = sim_class(model)
  File "/home/shaun/dev/nengo/nengo_ocl/nengo_ocl/simulator.py", line 303, in __init__
    self.model.build(network)
  ...
  File "/home/shaun/dev/nengo/nengo/nengo/cache.py", line 390, in cached_solver
    self._index[key] = (fd.name, start, end)
TypeError: 'NoneType' object does not support item assignment


Signed-off-by: Shaun Ren <shaun.ren@linux.com>