### PR TITLE
Nengo version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Packages
 *.egg
+.eggs/
 *.egg-info
 dist
 build

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -308,24 +308,17 @@ class Simulator(nengo.Simulator):
         self.ocl_only = ocl_only
 
         # --- Nengo build
-        if model is None or model.decoder_cache is None:
-            cache = get_default_decoder_cache()
-        else:
-            cache = model.decoder_cache
-
-        with cache, Timer() as nengo_timer:
+        with Timer() as nengo_timer:
             if model is None:
                 self.model = Model(dt=float(dt),
                                    label="%s, dt=%f" % (network, dt),
-                                   decoder_cache=cache)
+                                   decoder_cache=get_default_decoder_cache())
             else:
                 self.model = model
 
             if network is not None:
                 # Build the network into the model
                 self.model.build(network)
-
-            cache.shrink()
 
         logger.info("Nengo build in %0.3f s" % nengo_timer.duration)
 

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -279,11 +279,10 @@ class Simulator(nengo.Simulator):
         self.model = None
 
         # --- check version
-        if nengo.version.version_info[:2] != latest_nengo_version_info[:2]:
+        if nengo.version.version_info < latest_nengo_version_info:
             raise ValueError(
-                "This simulator only supports Nengo %s.x (got %s)" %
-                ('.'.join(str(i) for i in latest_nengo_version_info[:2]),
-                 nengo.__version__))
+                "This simulator only supports Nengo %s (got %s)" %
+                (latest_nengo_version, nengo.__version__))
         elif nengo.version.version_info > latest_nengo_version_info:
             warnings.warn("This version of `nengo_ocl` has not been tested "
                           "with your `nengo` version (%s). The latest fully "

--- a/nengo_ocl/version.py
+++ b/nengo_ocl/version.py
@@ -14,5 +14,5 @@ version = "{v}{dev}".format(v='.'.join(str(v) for v in version_info),
                             dev=('.dev%d' % dev) if dev is not None else '')
 
 # --- latest Nengo version at time of release
-latest_nengo_version_info = (2, 1, 0)  # (major, minor, patch)
+latest_nengo_version_info = (2, 1, 2)  # (major, minor, patch)
 latest_nengo_version = '.'.join(str(v) for v in latest_nengo_version_info)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test = pytest
+
 [check-manifest]
 ignore =
     .coveragerc

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     long_description=read('README.rst', 'CHANGES.rst'),
     zip_safe=False,
     install_requires=[
-        'nengo',
+        'nengo>=%s' % version_module.latest_nengo_version,
         'mako',
         'pyopencl',
     ],

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import imp
 import io
 import os
+import sys
 
 try:
     from setuptools import setup
@@ -24,6 +25,16 @@ def read(*filenames, **kwargs):
 root = os.path.dirname(os.path.realpath(__file__))
 version_module = imp.load_source(
     'version', os.path.join(root, 'nengo_ocl', 'version.py'))
+testing = 'test' in sys.argv or 'pytest' in sys.argv
+
+# Don't mess with added options if any are passed
+sysargs_overridden = False
+
+if '--addopts' not in sys.argv:
+    # Enable nengo tests by default
+    old_sysargs = sys.argv[:]
+    sys.argv[:] = old_sysargs + ['--addopts', '--pyargs nengo']
+    sysargs_overridden = True
 
 setup(
     name="nengo_ocl",
@@ -39,6 +50,7 @@ setup(
                  "Neural Engineering Framework"),
     long_description=read('README.rst', 'CHANGES.rst'),
     zip_safe=False,
+    setup_requires=['pytest-runner'] if testing else [],
     install_requires=[
         'nengo>=%s' % version_module.latest_nengo_version,
         'mako',
@@ -59,3 +71,6 @@ setup(
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
     ]
 )
+
+if sysargs_overridden:
+    sys.argv[:] = old_sysargs


### PR DESCRIPTION
@tbekolay, what do you think of this? I'm not quite sure why we were allowing Nengo versions less than the latest before. In the case of this repo, allowing this would cause problems if nengo v2.1.0 and the newest nengo_ocl were installed, since I'm now accommodating the cache changes (though nengo 2.1.2 made that unnecessary).