### PR TITLE
Updates for recent Nengo changes

### DIFF
--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -955,7 +955,13 @@ class Simulator(nengo.Simulator):
             bufpositions = self._cl_probe_plan.cl_bufpositions.get()
             assert np.all(bufpositions == 0)
 
-        with ProgressTracker(N, progress_bar) as progress:
+        try:
+            # Task required since Nengo 2.3.0
+            progress = ProgressTracker(N, progress_bar, "Simulating")
+        except TypeError:
+            progress = ProgressTracker(N, progress_bar)
+
+        with progress:
             # -- we will go through N steps of the simulator
             #    in groups of up to B at a time, draining
             #    the probe buffers after each group of B


### PR DESCRIPTION
We're hoping to push out a Nengo 2.3.0 release soon, so I made some changes to fix compatibility as a result of some recent changes, specifically https://github.com/nengo/nengo/pull/1151 and https://github.com/nengo/nengo/pull/1173.

With these commits, the tests run successfully for me with Nengo master (soon to be 2.3.0) and with the versions that previously worked (e.g. 2.1.2.).