### PR TITLE
Add Sphinx documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .eggs/
 *.egg-info
 dist
+_build
 build
 eggs
 parts

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,90 @@
+*************
+API reference
+*************
+
+.. default-role:: obj
+
+Simulator
+=========
+
+This is the Nengo OpenCL simulator.
+It uses the Nengo builder to take a model
+and turn it into signals and operators.
+Then, we copy all the signals into OCL,
+and create OCL versions of all the operators.
+This is what the ``Simulator.plan_*`` functions do;
+each one of them is responsible for
+creating an OCL kernel (or kernels)
+to execute the corresponding operator.
+
+.. autoclass:: nengo_ocl.Simulator
+
+clra_nonlinearities
+===================
+
+This is where the kernels for most operators are
+(i.e. most of the ``Simulator.plan_*`` functions
+call a ``plan_*`` function in here to generate the kernel).
+Each plan function follows roughly the same template:
+
+1. Do some checks on the arguments.
+2. Generate the C code for the kernel,
+   using Mako to fill in variable things like datatypes.
+3. Compile the C code as a PyOpenCL Program, and set the arguments.
+4. Create and return a `.Plan` object responsible for executing
+   that `pyopencl.Program`.
+
+.. automodule:: nengo_ocl.clra_nonlinearities
+    :members:
+
+clra_gemv
+=========
+
+This contains kernels specific to the GEMV
+(matrix-vector multiply) operation,
+since it's such an important and specialized operation.
+Most people will not need to know the details
+of this module.
+
+.. automodule:: nengo_ocl.clra_gemv
+    :members:
+
+RaggedArrays
+============
+
+You can think of a `.RaggedArray` a list of arrays.
+Whereas NumPy allows lists of arrays
+of the same size to be made into one big array
+(e.g. if you've got five 3x2 arrays,
+you can make a 5x3x2 array),
+there's no way to make arrays
+of different sizes into one big one.
+RaggedArray does this
+by making one big memory buffer where all the data is stored,
+and managing the reading and writing of that.
+
+.. autoclass:: nengo_ocl.raggedarray.RaggedArray
+
+.. autoclass:: nengo_ocl.clraggedarray.CLRaggedArray
+
+.. autofunction:: nengo_ocl.clraggedarray.data_ptr
+
+.. autofunction:: nengo_ocl.clraggedarray.to_host
+
+Operators
+=========
+
+.. automodule:: nengo_ocl.operators
+    :members:
+
+Python AST conversion
+=====================
+
+.. automodule:: nengo_ocl.ast_conversion
+    :members:
+
+Utils
+=====
+
+.. automodule:: nengo_ocl.utils
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+#
+# This file is execfile()d with the current directory set to its
+# containing dir.
+
+import os
+
+import nengo_ocl
+import sphinx_rtd_theme
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    'numpydoc',
+]
+
+# -- sphinx.ext.autodoc
+autoclass_content = 'both'  # class and __init__ docstrings are concatenated
+autodoc_default_flags = ['members']
+autodoc_member_order = 'bysource'  # default is alphabetical
+
+# -- sphinx.ext.intersphinx
+intersphinx_mapping = {
+    'nengo': ('http://pythonhosted.org/nengo/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'pyopencl': ('https://documen.tician.de/pyopencl/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+}
+
+# -- sphinx.ext.todo
+todo_include_todos = True
+# -- numpydoc config
+numpydoc_show_class_members = False
+
+# -- sphinx
+exclude_patterns = ['_build']
+source_suffix = '.rst'
+source_encoding = 'utf-8'
+master_doc = 'index'
+
+# Need to include https Mathjax path for sphinx < v1.3
+mathjax_path = ("https://cdn.mathjax.org/mathjax/latest/MathJax.js"
+                "?config=TeX-AMS-MML_HTMLorMML")
+
+project = u'Nengo OpenCL'
+authors = u'Nengo team'
+copyright = u'2017, Nengo team'
+version = '.'.join(nengo_ocl.__version__.split('.')[:2])  # Short X.Y version
+release = nengo_ocl.__version__  # Full version, with tags
+pygments_style = 'default'
+
+# -- Options for HTML output --------------------------------------------------
+
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_title = "Nengo OpenCL {0} docs".format(release)
+html_static_path = ['_static']
+html_context = {
+    'css_files': [os.path.join('_static', 'custom.css')],
+}
+html_use_smartypants = True
+htmlhelp_basename = 'NengoOCLdoc'
+html_last_updated_fmt = ''  # Suppress 'Last updated on:' timestamp
+html_show_sphinx = False
+
+# -- Options for LaTeX output -------------------------------------------------
+
+latex_elements = {
+    'papersize': 'letterpaper',
+    'pointsize': '11pt',
+    # 'preamble': '',
+}
+
+latex_documents = [
+    # (source start file, target, title, author, documentclass [howto/manual])
+    ('index', 'nengo_ocl.tex', html_title, authors, 'manual'),
+]
+
+# -- Options for manual page output -------------------------------------------
+
+man_pages = [
+    # (source start file, name, description, authors, manual section).
+    ('index', 'nengo_ocl', html_title, [authors], 1)
+]
+
+# -- Options for Texinfo output -----------------------------------------------
+
+texinfo_documents = [
+    # (source start file, target, title, author, dir menu entry,
+    #  description, category)
+    ('index', 'nengo_ocl', html_title, authors, 'Nengo OpenCL',
+     'Accelerated Nengo simulations with OpenCL', 'Miscellaneous'),
+]

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,51 @@
+**************************
+Frequently asked questions
+**************************
+
+How do I add a new kernel?
+==========================
+
+When you make a new Nengo neuron type or learning rule,
+it's unlikely that Nengo OpenCL
+will know how to simulate it.
+To teach Nengo OpenCL how to simulate it,
+you have to write an OpenCL kernel.
+
+A good starting point for this
+is to look at the existing kernels
+in ``nengo_ocl/clra_nonlinearities.py``
+and study one that is similar
+to the kernel you wish to add.
+For each kernel, you'll see
+that there are a lot of arguments that go in.
+Essentially, they're all lists
+of different aspects of the input ragged arrays.
+When we're doing computations with ragged arrays,
+essentially we want to write kernels
+that can take in a list of arrays of different sizes,
+and perform the operation on each one of those arrays.
+
+Let's take the BCM kernel as an example.
+It gets arguments ``shape0s`` and ``shape1s``;
+these are lists of the ``.shape[0]`` and ``.shape[1]`` for each output.
+Then we have ``pre_stride0s`` and ``pre_starts``;
+these give the strides along axis 0
+and a pointer to where the data starts
+for each array in the ``pre`` ragged array.
+``pre_data`` is the buffer itself.
+Then we have similar things for the ``post`` ragged array,
+followed by ``theta`` and ``delta``.
+Finally, there's a list of the alphas (learning rates)
+for all the different operators.
+So each of these lists will be of length N,
+where N is the number of ``SimBCM`` operators
+that we've combined into this single kernel.
+
+Then there's the kernel itself.
+It starts by getting ids, as is typical with OCL kernels.
+Here, ``k`` is the index of which array
+we're treating right now (0 <= k < N),
+so we use it to index into all of the input lists.
+``ij`` tells the kernel which individual element to treat.
+We split it into ``i`` and ``j`` (row and column indices),
+and then this kernel computes element (i, j) of the output (``delta``).

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,15 @@
+.. include:: ../README.rst
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   faq
+   api
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/nengo_ocl/ast_conversion.py
+++ b/nengo_ocl/ast_conversion.py
@@ -1,17 +1,18 @@
-"""
-This file holds a parser to turn simple Python functions into OCL code
+"""This module contains a parser to turn Python functions into OCL code.
 
-TODO:
-* better testing, i.e., write test cases for all the test functions
-  at the bottom of this file.
-* get binary_and, or, xor, etc. functions working (priority = low)
-  - this will require the ability to specify integer input variables
-  - or perhaps just cast inputs to these functions to integers
-* a danger right now is that there is no check that the user uses all passed
-  inputs in their function. For example, if the fn is meant to act on three
-  arguments, and the user makes a mistake in their model that passes a
-  5-vector to the function, no warning is issued. There's no obvious way to
-  deal with this better, though.
+.. todo:: Better testing, i.e., write test cases for all the test functions
+          at the bottom of this file.
+
+.. todo:: Get binary_and, or, xor, etc. functions working (priority = low)
+
+   * this will require the ability to specify integer input variables
+   * or perhaps just cast inputs to these functions to integers
+
+.. todo:: A danger right now is that there is no check that the user uses all
+   passed inputs in their function. For example, if the fn is meant to act on
+   three arguments, and the user makes a mistake in their model that passes a
+   5-vector to the function, no warning is issued. There's no obvious way to
+   deal with this better, though.
 """
 
 try:

--- a/nengo_ocl/clra_gemv.py
+++ b/nengo_ocl/clra_gemv.py
@@ -239,16 +239,13 @@ class gemv_prog(object):
 
 
 def ref_impl(p, items):
-    """
-    Return an OpenCL function to calculate elements `items` of
-    gemv operation `p`.
+    """Return an OCL function to calculate ``items`` of gemv operation ``p``.
 
-    In this reference implementation, we create a work item
-    per output number, or more specifically, a work grid
-    of (max_y_len, len(items)).  Each work item loops over the
-    dot products and the elements within each dot product to
-    compute the output value Y[global_id(1)][global_id(0)].
-
+    In this reference implementation, we create a work item per output number,
+    or more specifically, a work grid of shape ``(max_y_len, len(items))``.
+    Each work item loops over the  dot products and the elements within
+    each dot product to compute the output value
+    ``Y[global_id(1)][global_id(0)]``.
     """
 
     if p.clra_alpha is not None:

--- a/nengo_ocl/clraggedarray.py
+++ b/nengo_ocl/clraggedarray.py
@@ -20,8 +20,8 @@ Array.start = property(lambda self: self.offset / self.dtype.itemsize)
 def data_ptr(array):
     """Given an Array, get a Buffer that starts at the right offset
 
-    This fails unless `array.offset` is a multiple of
-    `queue.device.mem_base_addr_align`, which is rare, so this isn't really
+    This fails unless ``array.offset`` is a multiple of
+    ``queue.device.mem_base_addr_align``, which is rare, so this isn't really
     a good function.
     """
     if array.offset:

--- a/nengo_ocl/operators.py
+++ b/nengo_ocl/operators.py
@@ -7,7 +7,7 @@ from nengo.version import version_info as nengo_version
 
 
 class MultiDotInc(Operator):
-    """ y <- gamma + beta * y_in + \sum_i dot(A_i, x_i) """
+    """``y <- gamma + beta * y_in + \sum_i dot(A_i, x_i)``"""
 
     def __init__(self, Y, Y_in, beta, gamma, tag=None):
         assert Y.ndim == 1

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -105,11 +105,11 @@ class Simulator(object):
     Parameters
     ----------
     network, dt, seed, model
-        These parameters are the same as in ``nengo.Simulator``.
-    context : pyopencl.Context (optional)
+        These parameters are the same as in `nengo.Simulator`.
+    context : `pyopencl.Context` (optional)
         OpenCL context specifying which device(s) to run on. By default, we
-        will create a context by calling ``pyopencl.create_some_context()``
-        and use this context as the default for all subsequent ``Simulator``s.
+        will create a context by calling `pyopencl.create_some_context`
+        and use this context as the default for all subsequent instances.
     n_prealloc_probes : int (optional)
         Number of timesteps to buffer when probing. Larger numbers mean less
         data transfer with the device (faster), but use more device memory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,11 @@ test = pytest
 [bdist_wheel]
 universal = 1
 
+[build_sphinx]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
 [check-manifest]
 ignore =
     .coveragerc
@@ -17,3 +22,6 @@ ignore =
 exclude = __init__.py
 ignore = E123,E133,E226,E241,E242,E731,W503
 max-complexity = 30
+
+[upload_sphinx]
+upload-dir = docs/_build/html


### PR DESCRIPTION
Currently, the documentation contains the README, all classes or functions with docstrings, and a new FAQ that contains some information provided in #131. Likely some reorganization and many more docstrings would be welcome, but some documentation is better than no documentation, and this at least gives us a starting point to build from.

In order to render well and link to external projects' documentation, some changes were made to several docstrings. With these changes, the documentation builds without warnings with Sphinx 1.5.2.