### PR TITLE
Fix learning rules by allowing matrix copy

### DIFF
--- a/examples/benchmark_circconv.py
+++ b/examples/benchmark_circconv.py
@@ -144,6 +144,8 @@ for i, dim in enumerate(dims):
         print(records[-1])
         print("%s, dims=%d exception" % (sim_name, dim))
         raise
+    finally:
+        sim.close()
 
 filename = "records_circconv_%s.pkl" % ((
     datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")))

--- a/examples/profile_circconv.py
+++ b/examples/profile_circconv.py
@@ -58,9 +58,9 @@ with nengo.Network(label="ProfileConv", seed=3) as model:
     D_p = nengo.Probe(D.product.output)
 
 # --- simulation
-sim = nengo_ocl.Simulator(model, context=ctx, profiling=True)
-sim.run(1.0)
-sim.print_profiling(sort=1)
+with nengo_ocl.Simulator(model, context=ctx, profiling=True) as sim:
+    sim.run(1.0)
+    sim.print_profiling(sort=1)
 
 # --- results
 import matplotlib.pyplot as plt

--- a/examples/profile_pes.py
+++ b/examples/profile_pes.py
@@ -1,0 +1,47 @@
+import time
+
+import numpy as np
+import pyopencl as cl
+
+import nengo
+from nengo.networks.circularconvolution import circconv, transform_in
+
+import nengo_ocl
+
+ctx = cl.create_some_context()
+
+dims = 16
+# neurons_per_dim = 64
+neurons_per_dim = 256
+# neurons_per_dim = 1024
+n_neurons = dims * neurons_per_dim
+
+r = 1e-4
+W0 = np.random.uniform(-r, r, size=(n_neurons, n_neurons))
+
+runtime = 1.
+
+# --- model
+target_fn = lambda x: x**2
+pes = nengo.PES()
+
+with nengo.Network(label="ProfilePES", seed=3) as model:
+    x = nengo.Node(nengo.processes.WhiteSignal(runtime, high=1.), size_out=dims)
+    y = nengo.Node(size_in=dims)
+    nengo.Connection(x, y, function=target_fn)
+
+    a = nengo.Ensemble(n_neurons, dims)
+    b = nengo.Ensemble(n_neurons, dims)
+    nengo.Connection(x, a, synapse=None)
+
+    e = nengo.Ensemble(dims * neurons_per_dim, dims)
+    # nengo.Connection(b, e)  # time-consuming decoder finding involved
+    nengo.Connection(y, e, transform=-1)
+
+    c = nengo.Connection(a.neurons, b.neurons, transform=W0, learning_rule_type=pes)
+    nengo.Connection(e, c.learning_rule, synapse=None)
+
+# --- simulation
+sim = nengo_ocl.Simulator(model, context=ctx, profiling=True)
+sim.run(runtime)
+sim.print_profiling(sort=1)

--- a/examples/profile_pes.py
+++ b/examples/profile_pes.py
@@ -42,6 +42,6 @@ with nengo.Network(label="ProfilePES", seed=3) as model:
     nengo.Connection(e, c.learning_rule, synapse=None)
 
 # --- simulation
-sim = nengo_ocl.Simulator(model, context=ctx, profiling=True)
-sim.run(runtime)
-sim.print_profiling(sort=1)
+with nengo_ocl.Simulator(model, context=ctx, profiling=True) as sim:
+    sim.run(runtime)
+    sim.print_profiling(sort=1)

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -651,22 +651,22 @@ class Simulator(object):
 
         plans = []
         if copies:
-            A = self.all_data[[self.sidx[op.src] for op in copies]]
-            B = self.all_data[[self.sidx[op.dst] for op in copies]]
+            X = self.all_data[[self.sidx[op.src] for op in copies]]
+            Y = self.all_data[[self.sidx[op.dst] for op in copies]]
             incs = np.array([op.inc for op in copies], dtype=np.int32)
-            plans.append(plan_copy(self.queue, A, B, incs))
+            plans.append(plan_copy(self.queue, X, Y, incs))
 
         if ops:
-            A = self.all_data[[self.sidx[op.src] for op in ops]]
-            B = self.all_data[[self.sidx[op.dst] for op in ops]]
+            X = self.all_data[[self.sidx[op.src] for op in ops]]
+            Y = self.all_data[[self.sidx[op.dst] for op in ops]]
             inds = lambda ary, i: np.arange(ary.size, dtype=np.int32)[
                 Ellipsis if i is None else i]
-            Ainds = self.RaggedArray(
+            Xinds = self.RaggedArray(
                 [inds(op.src, op.src_slice) for op in ops])
-            Binds = self.RaggedArray(
+            Yinds = self.RaggedArray(
                 [inds(op.dst, op.dst_slice) for op in ops])
             incs = np.array([op.inc for op in ops], dtype=np.int32)
-            plans.append(plan_slicedcopy(self.queue, A, B, Ainds, Binds, incs))
+            plans.append(plan_slicedcopy(self.queue, X, Y, Xinds, Yinds, incs))
 
         return plans
 

--- a/nengo_ocl/tests/test_ast_conversion.py
+++ b/nengo_ocl/tests/test_ast_conversion.py
@@ -60,8 +60,8 @@ def _test_node(OclOnlySimulator, fn, size_in=0):
             nengo.Connection(u, v, synapse=0)
 
     # run model
-    sim = OclOnlySimulator(model)
-    sim.run(0.005)
+    with OclOnlySimulator(model) as sim:
+        sim.run(0.005)
 
     # compare output
     t = sim.trange()
@@ -187,10 +187,10 @@ def _test_conn(OclOnlySimulator, fn, size_in, dist_in=None, n=1):
             probes.append(nengo.Probe(w))
 
     # run model
-    sim = OclOnlySimulator(model)
-    sim.step()
-    # sim.step()
-    # sim.step()
+    with OclOnlySimulator(model) as sim:
+        sim.step()
+        # sim.step()
+        # sim.step()
 
     # compare output
     z = np.array([sim.data[p][-1] for p in probes])


### PR DESCRIPTION
Nengo 2.5.0 uses a matrix copy in learning rules rather than an
elementwise-inc. The plan_copy function needed to be accommodated
to allow matrices.

Fixes #145.