### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,10 +18,19 @@ Release History
    - Bugfixes
    - Documentation
 
-1.2.1 (unreleased)
-==================
+1.3.0 (October 6, 2017)
+=======================
 
+**Improvements**
 
+- Supports recent Nengo versions, up to 2.6.0.
+
+**Bugfixes**
+
+- Fixed an issue in which stochastic processes would not be
+  fully reset on simulator reset.
+- Fixed an issue in which building a model multiple times
+  could result in old probe data persisting.
 
 1.2.0 (February 23, 2017)
 =========================

--- a/nengo_ocl/simulator.py
+++ b/nengo_ocl/simulator.py
@@ -681,6 +681,13 @@ class Simulator(object):
             plans.append(plan_copy(self.queue, X, Y, incs))
 
         if ops:
+            dupl = lambda s: (
+                s is not None
+                and not (isinstance(s, np.ndarray) and s.dtype == np.bool)
+                and len(s) != len(set(s)))
+            if any(dupl(op.src_slice) or dupl(op.dst_slice) for op in ops):
+                raise NotImplementedError("Duplicates in indices")
+
             X = self.all_data[[self.sidx[op.src] for op in ops]]
             Y = self.all_data[[self.sidx[op.dst] for op in ops]]
             inds = lambda ary, i: np.arange(ary.size, dtype=np.int32)[

--- a/nengo_ocl/version.py
+++ b/nengo_ocl/version.py
@@ -8,8 +8,8 @@ a release version. Release versions are git tagged with the version.
 
 # --- version of this release
 name = "nengo_ocl"
-version_info = (1, 2, 1)  # (major, minor, patch)
-dev = 0
+version_info = (1, 3, 0)  # (major, minor, patch)
+dev = None
 version = "{v}{dev}".format(v='.'.join(str(v) for v in version_info),
                             dev=('.dev%d' % dev) if dev is not None else '')
 
@@ -23,5 +23,5 @@ bad_nengo_versions = [
 ]
 
 # --- latest Nengo version at time of release
-latest_nengo_version_info = (2, 3, 1)  # (major, minor, patch)
+latest_nengo_version_info = (2, 6, 0)  # (major, minor, patch)
 latest_nengo_version = '.'.join(str(v) for v in latest_nengo_version_info)


### PR DESCRIPTION
This is the release commit for v1.3.0, and a commit to fix / xfail some recent Nengo changes:

- https://github.com/nengo/nengo/pull/1357 changed what happens in `sim.run`; those changes were ported back here no problem
- https://github.com/nengo/nengo/pull/1361 fixed a bug with repeated indices in lists used to slice Nengo objects; those tests fail here so I xfailed them for now
- https://github.com/nengo/nengo/pull/1355 introduced a Piecewise process with interpolation. The interpolation tests fail because we're evaluating the function at `t=0.1`, which in Nengo OpenCL's float32 in slightly more than `0.1`, resulting in the interpolation function returning `0`, which is the fill value. There are some things we could do the fix this (namely having the `interp1d` extrapolate instead of filling with 0) but that'll take some discussion, so xfailing it for now so we can get the release done